### PR TITLE
Avoid Go 1.5's strings.Compare

### DIFF
--- a/rewrite/command.go
+++ b/rewrite/command.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -64,7 +63,7 @@ func (li ListItemSort) Len() int      { return len(li) }
 func (li ListItemSort) Swap(i, j int) { li[i], li[j] = li[j], li[i] }
 func (li ListItemSort) Less(i, j int) bool {
 	if li[i].Status == li[j].Status {
-		return strings.Compare(li[i].Path, li[j].Path) < 0
+		return li[i].Path < li[j].Path
 	}
 	return li[i].Status > li[j].Status
 }

--- a/rewrite/vendorFile.go
+++ b/rewrite/vendorFile.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/kardianos/vendor/internal/github.com/dchest/safefile"
 )
@@ -57,9 +56,9 @@ func (vp vendorPackageSort) Len() int      { return len(vp) }
 func (vp vendorPackageSort) Swap(i, j int) { vp[i], vp[j] = vp[j], vp[i] }
 func (vp vendorPackageSort) Less(i, j int) bool {
 	if vp[i].Local == vp[j].Local {
-		return strings.Compare(vp[i].Vendor, vp[j].Vendor) < 0
+		return vp[i].Vendor < vp[j].Vendor
 	}
-	return strings.Compare(vp[i].Local, vp[j].Local) < 0
+	return vp[i].Local < vp[j].Local
 }
 
 func writeVendorFile(root string, vf *VendorFile) (err error) {


### PR DESCRIPTION
So it builds on 1.4. Not sure if there's some other distinction here I'm missing.